### PR TITLE
Support for model packages, improved docs, polish dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,46 @@ further information.
 
 More about Ebean: http://www.avaje.org
 
-NOTE:
-Obviously this module lacks documentation. Feel free to
-contribute to the project and the wiki. Thanks!
+Overview
+--------
 
+This module works with a wide range of Ebean versions. It currently uses a 
+minimum version of ebean v3.2.5, but has also been tested with the latest versions
+in the 4.x series. Since this module more or less configures the ebean server,
+it should be compatible with any ebean release that continues to support those
+configuration properties.
+
+NOTE: This module only supports a single (default) ebean server.  Feel free to
+contribute code to the project if you need other features. Thanks!
 
 Setup
 -----
 
-1) Add you db conf to your application.conf file. For instance:
+1) Add your db conf to your application.conf file. For a simple H2 database:
 
     ebean.datasource.databaseUrl=jdbc:h2:testdatabase:tests;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE
  
+For a MySQL database (you'll also need to add the MySQL driver dependency to
+your project)
+
+    ebean.ddl.generate = false
+    ebean.ddl.run = false
+    ebean.models = com.company.models.*,org.otherorg.models.Foo
+    ebean.datasource.name = NameOfEbeanServer
+    ebean.datasource.databaseUrl = jdbc:mysql://localhost:3306/dbname
+    ebean.datasource.databaseDriver = com.mysql.jdbc.Driver
+    ebean.datasource.username = root
+    ebean.datasource.password = test
+
+Please note that <code>ebean.models</code> accepts a comma delimited list of
+both class names as well as packages (just make sure it ends with .*)
+
 2) Add the ninja-ebeans dependency to your pom.xml:
 
     <dependency>
         <groupId>org.ninjaframework</groupId>
         <artifactId>ninja-ebean-module</artifactId>
-        <version>1.1</version>
+        <version>1.4.1</version>
     </dependency>
     
 3) Add ebean's enhancer plugin to your pom.xml:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+1.4.1
+=====
+ 
+ * 2015-03-12 H2 DB now in provided scope so downstream projects do not need to manually
+   exclude it (if they are using another vendor)
+ * 2015-03-12 ebean.models accepts packages -- simply add a ".*" at the end of the package
+   name to differentiate it from a single classname.
+ * 2015-03-12 Factory method to create ebean server in NinjaEbeanServerLifecycle
+   to allow subclasses to override config.
+
 1.4.0
 =====
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
  
  * 2015-03-12 H2 DB now in provided scope so downstream projects do not need to manually
    exclude it (if they are using another vendor)
+ * 2015-03-12 javax.persistence now in provided scope so downstream projects do not need to manually
+   exclude it (if they are using another vendor)
  * 2015-03-12 ebean.models accepts packages -- simply add a ".*" at the end of the package
    name to differentiate it from a single classname.
  * 2015-03-12 Factory method to create ebean server in NinjaEbeanServerLifecycle

--- a/ninja-ebean-demo/src/test/java/ninja/ebean/NinjaEbeanServerLifecycleTest.java
+++ b/ninja-ebean-demo/src/test/java/ninja/ebean/NinjaEbeanServerLifecycleTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.sql.SQLException;
-import java.util.logging.Logger;
 
 import ninja.lifecycle.Dispose;
 import ninja.lifecycle.Start;
@@ -35,6 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NinjaEbeanServerLifecycleTest {

--- a/ninja-ebean-module/pom.xml
+++ b/ninja-ebean-module/pom.xml
@@ -31,6 +31,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.avaje.ebeanorm</groupId>
+            <artifactId>avaje-ebeanorm</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        
+        <dependency>
             <groupId>org.ninjaframework</groupId>
             <artifactId>ninja-core</artifactId>
             <version>${ninja.version}</version>
@@ -41,12 +47,7 @@
             <groupId>javax.persistence</groupId>
             <artifactId>persistence-api</artifactId>
             <version>1.0.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.avaje.ebeanorm</groupId>
-            <artifactId>avaje-ebeanorm</artifactId>
-            <version>3.2.5</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/ninja-ebean-module/pom.xml
+++ b/ninja-ebean-module/pom.xml
@@ -53,6 +53,7 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.3.175</version>
+            <scope>provided</scope>
         </dependency>
 
 

--- a/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanProperties.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanProperties.java
@@ -35,6 +35,12 @@ public interface NinjaEbeanProperties {
      * make that reliable you can use that property.
      * 
      * ebean.models=model.myModel1, model.myModel2
+     * 
+     * To register all classes in a package, simply append a ".*" at the end
+     * of your model name.
+     * 
+     * ebean.models=model.MyModel1,com.company.models.*
+     * 
      */
     public final String EBEAN_MODELS = "ebean.models";
 

--- a/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
@@ -108,7 +108,7 @@ public class NinjaEbeanServerLifecycle {
 
         ServerConfig serverConfig = new ServerConfig();
         serverConfig.setName(ebeanDatasourceName);
-
+        
         // Define DataSource parameters
         DataSourceConfig dataSourceConfig = new DataSourceConfig();
         dataSourceConfig.setDriver(ebeanDatasourceDatabaseDriver);
@@ -151,11 +151,23 @@ public class NinjaEbeanServerLifecycle {
         
 
         // create the EbeanServer instance
-        ebeanServer = EbeanServerFactory.create(serverConfig);
+        ebeanServer = createEbeanServer(serverConfig);
         
         // Activate the Ebean shutdown manager (disconnects from db, shuts down all threads and so on)
         ShutdownManager.touch();
 
+    }
+    
+    /**
+     * Creates the Ebean server with the prepared server config.  Provides a
+     * last chance to modify the config in a subclass if you'd like to customize
+     * the config further.
+     * 
+     * @param serverConfig The prepared server config
+     * @return The newly created Ebean server
+     */
+    public EbeanServer createEbeanServer(ServerConfig serverConfig) {
+        return EbeanServerFactory.create(serverConfig);
     }
 
     public EbeanServer getEbeanServer() {

--- a/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
@@ -128,28 +128,38 @@ public class NinjaEbeanServerLifecycle {
         serverConfig.setDefaultServer(true);
         serverConfig.setRegister(true);
 
-        
         serverConfig.addPackage("models");
         
         // add manually listed classes from the property
-        String [] manuallyListedModels = ninjaProperties.getStringArray(EBEAN_MODELS);
+        String[] manuallyListedModels = ninjaProperties.getStringArray(EBEAN_MODELS);
         
         if (manuallyListedModels != null) {
         
             for (String model : manuallyListedModels) {
     
-                try {
+                if (model.endsWith(".*")) {
+                    
+                    // strip off .* at end
+                    String packageName = model.substring(0, model.length() - 2);
+                    
+                    serverConfig.addPackage(packageName);
+                    
+                }
+                else {
                 
-                    serverConfig.addClass(Class.forName(model));
-                
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(
-                            "Configuration error. Class not listed in " + EBEAN_MODELS + " not found: " + model);
+                    try {
+
+                        serverConfig.addClass(Class.forName(model));
+
+                    } catch (ClassNotFoundException e) {
+                        throw new RuntimeException(
+                                "Configuration error. Class not listed in " + EBEAN_MODELS + " not found: " + model);
+                    }
+                    
                 }
             }
         }
         
-
         // create the EbeanServer instance
         ebeanServer = createEbeanServer(serverConfig);
         

--- a/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
@@ -28,8 +28,6 @@ import static ninja.ebean.NinjaEbeanProperties.EBEAN_DDL_GENERATE;
 import static ninja.ebean.NinjaEbeanProperties.EBEAN_DDL_RUN;
 import static ninja.ebean.NinjaEbeanProperties.EBEAN_MODELS;
 
-import java.util.logging.Logger;
-
 import ninja.utils.NinjaProperties;
 
 import com.avaje.ebean.EbeanServer;
@@ -39,6 +37,9 @@ import com.avaje.ebean.config.ServerConfig;
 import com.avaje.ebeaninternal.server.lib.ShutdownManager;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.slf4j.Logger;
 
 /**
  * This is an internal class of Ninja Ebeans support. It is responsible for
@@ -66,7 +67,6 @@ public class NinjaEbeanServerLifecycle {
         this.ninjaProperties = ninjaProperties;
         
         startServer();
-        
     }
 
     /**
@@ -74,7 +74,7 @@ public class NinjaEbeanServerLifecycle {
      * your application.conf file and configures Ebean accordingly.
      * 
      */
-    public void startServer(){
+    public final void startServer(){
         logger.info("Starting Ebeans Module.");
 
         // /////////////////////////////////////////////////////////////////////
@@ -128,36 +128,75 @@ public class NinjaEbeanServerLifecycle {
         serverConfig.setDefaultServer(true);
         serverConfig.setRegister(true);
 
-        serverConfig.addPackage("models");
+        // split models configuration into classes & packages
+        Set<String> packageNames = new LinkedHashSet<>();
+        Set<Class<?>> entityClasses = new LinkedHashSet<>();
+        
+        // models always added by default
+        packageNames.add("models");
         
         // add manually listed classes from the property
         String[] manuallyListedModels = ninjaProperties.getStringArray(EBEAN_MODELS);
         
         if (manuallyListedModels != null) {
-        
+            
             for (String model : manuallyListedModels) {
-    
+                
                 if (model.endsWith(".*")) {
                     
                     // strip off .* at end
                     String packageName = model.substring(0, model.length() - 2);
                     
-                    serverConfig.addPackage(packageName);
+                    packageNames.add(packageName);
                     
                 }
                 else {
-                
+                    
                     try {
 
-                        serverConfig.addClass(Class.forName(model));
+                        entityClasses.add(Class.forName(model));
 
                     } catch (ClassNotFoundException e) {
                         throw new RuntimeException(
-                                "Configuration error. Class not listed in " + EBEAN_MODELS + " not found: " + model);
+                            "Configuration error. Class listed/discovered via " + EBEAN_MODELS + " not found: " + model);
                     }
                     
                 }
+                
             }
+            
+        }
+        
+        // if any packages were specified the reflections library MUST be available
+        if (!packageNames.isEmpty()) {
+            
+            for (String packageName : packageNames) {
+                
+                Set<String> packageClasses
+                        = ReflectionsHelper.findAllClassesInPackage(packageName);
+                
+                logger.info("Searched and found " + packageClasses.size() + " classes in package " + packageName);
+                
+                for (String packageClass : packageClasses) {
+                    
+                    try {
+                        entityClasses.add(Class.forName(packageClass));
+                    }
+                    catch (ClassNotFoundException e) {
+                        // should be impossible since Reflections just found 'em
+                        throw new RuntimeException("Something fishy happenend. Unable to find class " + packageClass);
+                    }
+                    
+                }
+                
+            }
+            
+        }
+        
+        for (Class<?> entityClass : entityClasses) {
+            
+            serverConfig.addClass(entityClass);
+
         }
         
         // create the EbeanServer instance

--- a/ninja-ebean-module/src/main/java/ninja/ebean/ReflectionsHelper.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/ReflectionsHelper.java
@@ -1,0 +1,34 @@
+package ninja.ebean;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ *
+ * @author joelauer
+ */
+public class ReflectionsHelper {
+    
+    static public Set<String> findAllClassesInPackage(String packageName) {
+        try {
+            ClassPath cp = ClassPath.from(ReflectionsHelper.class.getClassLoader());
+
+             ImmutableSet<ClassPath.ClassInfo> classes = cp.getTopLevelClasses(packageName);
+
+             Set<String> classNames = new LinkedHashSet<>();
+
+             for (ClassPath.ClassInfo ci : classes) {
+                 classNames.add(ci.getName());
+             }
+
+             return classNames;
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+    
+}


### PR DESCRIPTION
* H2 DB & javax.persistence dependencies moved to provided scope so downstream projects do not need to manually exclude it (if they are using another vendor)

* ebean.models accepts packages -- simply add a ".*" at the end of the package name to differentiate it from a single classname

* Factory method to create ebean server in NinjaEbeanServerLifecycle to allow subclasses to override config.