### PR TITLE
Explicitly call loadFromProperties() and default DDL props to false

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 X.X.X
 =====
 
- * 2015-08-27 Ebean DDL properties default to false to avoid accidental database recreation
- * 2015-08-27 Call loadFromProperties() explicitly to avoid NPE in Ebean 6.4.1
+ * 2015-08-27 Ebean DDL properties default to false to avoid accidental database recreation (metacity)
+ * 2015-08-27 Call loadFromProperties() explicitly to avoid NPE in Ebean 6.4.1 (metacity)
 
 1.5.0
 =====

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+X.X.X
+=====
+
+ * 2015-08-27 Ebean DDL properties default to false to avoid accidental database recreation
+ * 2015-08-27 Call loadFromProperties() explicitly to avoid NPE in Ebean 6.4.1
+
 1.5.0
 =====
 

--- a/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
@@ -81,9 +81,9 @@ public class NinjaEbeanServerLifecycle {
         // Setup basic parameters
         // /////////////////////////////////////////////////////////////////////
         boolean ebeanDdlGenerate = ninjaProperties.getBooleanWithDefault(
-                EBEAN_DDL_GENERATE, true);
+                EBEAN_DDL_GENERATE, false);
         boolean ebeanDdlRun = ninjaProperties.getBooleanWithDefault(
-                EBEAN_DDL_RUN, true);
+                EBEAN_DDL_RUN, false);
 
         String ebeanDatasourceName = ninjaProperties.getWithDefault(
                 EBEAN_DATASOURCE_NAME, "default");
@@ -108,6 +108,7 @@ public class NinjaEbeanServerLifecycle {
 
         ServerConfig serverConfig = new ServerConfig();
         serverConfig.setName(ebeanDatasourceName);
+        serverConfig.loadFromProperties();
         
         // Define DataSource parameters
         DataSourceConfig dataSourceConfig = new DataSourceConfig();


### PR DESCRIPTION
Ebean 6.4.1 introduced some code that expects a non-null Properties to exists in ServerConfig. This fixes [the NPE that will be thrown](https://github.com/ebean-orm/avaje-ebeanorm/blob/avaje-ebeanorm-6.4.1/src/main/java/com/avaje/ebeaninternal/server/changelog/DefaultChangeLogListener.java#L62) in the current version. 

I also propose defaulting Ebean DDL related properties to `false` to avoid scenarios where the DDL properties are undefined in Ninja's prod mode - currently this would result in dropping and recreation of the database. 