### PR TITLE
Expose DDL Seed and Init SQL properties 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,9 @@ target
 
 # no sql DDL stuff
 *.sql
+
+# except for demo seed database file
+!database.seed.sql
+
 # no h2 databases
 *.db

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ your project)
     ebean.datasource.username = root
     ebean.datasource.password = test
 
+
 Please note that <code>ebean.models</code> accepts a comma delimited list of
 both class names as well as packages (just make sure it ends with .*)
 
@@ -74,23 +75,21 @@ both class names as well as packages (just make sure it ends with .*)
 3) Add ebean's enhancer plugin to your pom.xml:
 
     <plugin>
-        <groupId>org.avaje</groupId>
-        <artifactId>ebean-maven-enhancement-plugin</artifactId>
-        <version>2.8.1</version>
+        <groupId>org.avaje.ebeanorm</groupId>
+        <artifactId>avaje-ebeanorm-mavenenhancer</artifactId>
+        <version>4.7.1</version>
         <executions>
             <execution>
-                <id>main</id>
+                <id>ebean-enhancer</id>
                 <phase>process-classes</phase>
+                <configuration>
+                    <classSource>${project.build.outputDirectory}</classSource>
+                    <packages>models</packages>
+                    <transformArgs>debug=1</transformArgs>
+                </configuration>
                 <goals>
                     <goal>enhance</goal>
                 </goals>
-                <configuration>
-                    <packages>models</packages>
-                    <transformArgs>debug=1</transformArgs>
-                    <!-- workaround against bug in ebean: https://groups.google.com/forum/?fromgroups#!topic/ebean/w2Q6PSeXKAk%5B1-25%5D -->
-                    <classSource>${project.build.outputDirectory}</classSource>
-                    <classDestination>${project.build.outputDirectory}</classDestination>
-                </configuration>
             </execution>
         </executions>
     </plugin>

--- a/ninja-ebean-demo/pom.xml
+++ b/ninja-ebean-demo/pom.xml
@@ -75,34 +75,26 @@
                 </configuration>
             </plugin>
 
-
             <plugin>
-                <groupId>org.avaje</groupId>
-                <artifactId>ebean-maven-enhancement-plugin</artifactId>
-                <version>2.8.1</version>
+                <groupId>org.avaje.ebeanorm</groupId>
+                <artifactId>avaje-ebeanorm-mavenenhancer</artifactId>
+                <version>4.7.1</version>
                 <executions>
                     <execution>
-                        <id>main</id>
+                        <id>ebean-enhancer</id>
                         <phase>process-classes</phase>
+                        <configuration>
+                            <classSource>${project.build.outputDirectory}</classSource>
+                            <packages>models</packages>
+                            <transformArgs>debug=1</transformArgs>
+                        </configuration>
                         <goals>
                             <goal>enhance</goal>
                         </goals>
-                        <configuration>
-                            <packages>models</packages>
-                            <transformArgs>debug=1</transformArgs>
-                            <!-- workaround against bug in ebean: https://groups.google.com/forum/?fromgroups#!topic/ebean/w2Q6PSeXKAk%5B1-25%5D -->
-                            <classSource>${project.build.outputDirectory}</classSource>
-                            <classDestination>${project.build.outputDirectory}</classDestination>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
-
-
-
-
-
-
+           
             <!-- Tell the surefire plugin (responsible for test) -->
             <!-- not to use system classloader. Otherwise Ebean model registration -->
             <!-- does not work -->
@@ -123,6 +115,12 @@
         <resources>
             <resource>
                 <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
                 <includes>
                     <include>**/*</include>
                 </includes>
@@ -192,7 +190,19 @@
             <version>${ninja.version}</version>
             <scope>test</scope>
         </dependency>
-
+        
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.3.175</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>persistence-api</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        
     </dependencies>
 
 

--- a/ninja-ebean-demo/pom.xml
+++ b/ninja-ebean-demo/pom.xml
@@ -129,6 +129,7 @@
 
         <pluginManagement>
             <plugins>
+                <!-- Taken Directly from: http://stackoverflow.com/questions/11996507/how-do-i-enable-ebean-enhancement-in-maven -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -138,19 +139,16 @@
                             <pluginExecutions>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
-                                        <groupId>org.avaje</groupId>
-                                        <artifactId>
-                                            ebean-maven-enhancement-plugin
-                                        </artifactId>
-                                        <versionRange>
-                                            [2.7.7,)
-                                        </versionRange>
+                                        <groupId>org.avaje.ebeanorm</groupId>
+                                        <artifactId>avaje-ebeanorm-mavenenhancer</artifactId>
+                                        <versionRange>[3.3.2,)</versionRange>
                                         <goals>
                                             <goal>enhance</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
                                         <execute>
+                                            <runOnConfiguration>true</runOnConfiguration>
                                             <runOnIncremental>true</runOnIncremental>
                                         </execute>
                                     </action>

--- a/ninja-ebean-demo/src/main/java/conf/application.conf
+++ b/ninja-ebean-demo/src/main/java/conf/application.conf
@@ -16,6 +16,11 @@ application.name=ninja demo application
 
 application.cookie.prefix=NINJA
 
+ebean.ddl.generate=true
+ebean.ddl.run=true
+
+ebean.ddl.seedSql=database.seed.sql
+
 #ISO Language Code, optionally followed by a valid ISO Country Code. 
 application.languages=en,de
 

--- a/ninja-ebean-demo/src/main/resources/database.seed.sql
+++ b/ninja-ebean-demo/src/main/resources/database.seed.sql
@@ -1,0 +1,2 @@
+INSERT INTO guestbook_entry (ID,EMAIL,CONTENT, LAST_UPDATE) 
+VALUES (1000, 'example@example.org', 'Inserted via ebean.ddl.seedSql property', GETDATE());

--- a/ninja-ebean-demo/src/test/java/ninja/ebean/NinjaEbeanServerLifecycleTest.java
+++ b/ninja-ebean-demo/src/test/java/ninja/ebean/NinjaEbeanServerLifecycleTest.java
@@ -69,9 +69,9 @@ public class NinjaEbeanServerLifecycleTest {
             // Verify that properties are correct
             // /////////////////////////////////////////////////////////////////////
             verify(ninjaProperties).getBooleanWithDefault("ebean.ddl.generate",
-                    true);
+                    false);
             verify(ninjaProperties)
-                    .getBooleanWithDefault("ebean.ddl.run", true);
+                    .getBooleanWithDefault("ebean.ddl.run", false);
 
             verify(ninjaProperties).getWithDefault("ebean.datasource.name",
                     "default");
@@ -96,7 +96,10 @@ public class NinjaEbeanServerLifecycleTest {
             
             verify(ninjaProperties).getStringArray(
                     "ebean.models");
-
+            
+            verify(ninjaProperties).get("ebean.ddl.initSql");
+            
+            verify(ninjaProperties).get("ebean.ddl.seedSql");
             // be nice and stop the server afterwards
             //ninjaEbeanServerLifecycle.stopServer();
         } catch (Exception e) {

--- a/ninja-ebean-module/pom.xml
+++ b/ninja-ebean-module/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.avaje.ebeanorm</groupId>
             <artifactId>avaje-ebeanorm</artifactId>
-            <version>3.2.5</version>
+            <version>6.16.4</version>
         </dependency>
         
         <dependency>

--- a/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanProperties.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanProperties.java
@@ -47,6 +47,9 @@ public interface NinjaEbeanProperties {
     public final String EBEAN_DDL_GENERATE = "ebean.ddl.generate";
     public final String EBEAN_DDL_RUN = "ebean.ddl.run";
 
+    public final String EBEAN_DDL_SEED_SQL = "ebean.ddl.seedSql";
+    public final String EBEAN_DDL_INIT_SQL = "ebean.ddl.initSql";
+     
     public final String EBEAN_DATASOURCE_USERNAME = "ebean.datasource.username";
     public final String EBEAN_DATASOURCE_PASSWORD = "ebean.datasource.password";
     
@@ -58,4 +61,5 @@ public interface NinjaEbeanProperties {
     public final String EBEAN_DATASOURCE_HEARTBEAT_SQL = "ebean.datasource.heartbeatsql";
     public final String EBEAN_DATASOURCE_ISOLATION_LEVEL = "ebean.datasource.isolationlevel";
 
+    
 }

--- a/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
+++ b/ninja-ebean-module/src/main/java/ninja/ebean/NinjaEbeanServerLifecycle.java
@@ -26,6 +26,10 @@ import static ninja.ebean.NinjaEbeanProperties.EBEAN_DATASOURCE_PASSWORD;
 import static ninja.ebean.NinjaEbeanProperties.EBEAN_DATASOURCE_USERNAME;
 import static ninja.ebean.NinjaEbeanProperties.EBEAN_DDL_GENERATE;
 import static ninja.ebean.NinjaEbeanProperties.EBEAN_DDL_RUN;
+import static ninja.ebean.NinjaEbeanProperties.EBEAN_DDL_INIT_SQL;
+import static ninja.ebean.NinjaEbeanProperties.EBEAN_DDL_SEED_SQL;
+
+
 import static ninja.ebean.NinjaEbeanProperties.EBEAN_MODELS;
 
 import ninja.utils.NinjaProperties;
@@ -85,6 +89,9 @@ public class NinjaEbeanServerLifecycle {
         boolean ebeanDdlRun = ninjaProperties.getBooleanWithDefault(
                 EBEAN_DDL_RUN, false);
 
+        String ebeanDdlInitSql = ninjaProperties.get(EBEAN_DDL_INIT_SQL);
+        String ebeanDdlSeedSql = ninjaProperties.get(EBEAN_DDL_SEED_SQL);
+        
         String ebeanDatasourceName = ninjaProperties.getWithDefault(
                 EBEAN_DATASOURCE_NAME, "default");
         String ebeanDatasourceUserName = ninjaProperties.getWithDefault(
@@ -125,6 +132,8 @@ public class NinjaEbeanServerLifecycle {
         // set DDL options...
         serverConfig.setDdlGenerate(ebeanDdlGenerate);
         serverConfig.setDdlRun(ebeanDdlRun);
+        serverConfig.setDdlInitSql(ebeanDdlInitSql);
+        serverConfig.setDdlSeedSql(ebeanDdlSeedSql);
 
         serverConfig.setDefaultServer(true);
         serverConfig.setRegister(true);


### PR DESCRIPTION
Ebeans now supports 2 new configuration properties that allow users to run SQL scripts before and after ddl runs. 

https://github.com/ebean-orm/avaje-ebeanorm/issues/515

There is 

* ebean.ddl.initSql - runs before creating tables
* ebean.ddl.seedSql- runs after creating tables

This PR focuses on the Seed SQL functionality as I find it more useful, but the initSql functionality has been exposed and I ensured it at least is called.

The following updates have been made

* Major bump of ebeans orm version to get access to new seedSql/InitSql functionality (from 3.x -> 6.x)
* Updated ebeans enhancer plugin as required by new ebeans orm version used
* Updated README with new enhancer plugin information
* Fixed Demo application as it had been broken by previous Pull Requests. Specifically some dependencies in the ebeans-module were scoped, so unavailable to the Demo. Also DDL functionality is now off by default were as the Demo tests were expecting that behavior to be on by default.
* Added an example of how to use the seedSql scripts in the demo application. Useful for knowing where to place the seed SQL file


